### PR TITLE
Fix linter settings and errors

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -3,9 +3,10 @@ package main
 import (
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/engineerd/wasm-to-oci/pkg/oci"
 	"github.com/engineerd/wasm-to-oci/pkg/tuf"
-	"github.com/spf13/cobra"
 )
 
 type pullOptions struct {

--- a/golangci.yml
+++ b/golangci.yml
@@ -16,4 +16,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/deislabs/duffle
+    local-prefixes: github.com/engineerd/wasm-to-oci


### PR DESCRIPTION
The `goimports` settings in the linter options were wrong, meaning `goimports` was not running properly.

This PR fixes that, as well as the linter error in `cmd/pull.go`.

Signed-off-by: Radu M <root@radu.sh>