### PR TITLE
fix: Typos in descriptions and comments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,8 +40,8 @@ func main() {
 	cmd.PersistentFlags().StringVarP(&trustDir, "dir", "d", defaultTrustDir(), "Directory where the trust data is persisted to")
 	cmd.PersistentFlags().StringVar(&logLevel, "log", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
 	cmd.PersistentFlags().StringVarP(&timeout, "timeout", "t", "5s", `Timeout for the trust server`)
-	cmd.PersistentFlags().BoolVarP(&insecure, "insecure", "", false, "allow connections to SSL registry without certs")
-	cmd.PersistentFlags().BoolVarP(&useHTTP, "use-http", "", false, "use plain http and not https")
+	cmd.PersistentFlags().BoolVarP(&insecure, "insecure", "", false, "Allow connections to SSL registry without certs")
+	cmd.PersistentFlags().BoolVarP(&useHTTP, "use-http", "", false, "Use plain http instead of https")
 
 	cmd.AddCommand(newPushCmd(), newPullCmd())
 	if err := cmd.Execute(); err != nil {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -22,7 +22,7 @@ func newPushCmd() *cobra.Command {
 	var opts pushOptions
 	cmd := &cobra.Command{
 		Use:   "push <module> <reference> [options]",
-		Short: "Pushes a WASM module from an OCI registry",
+		Short: "Pushes a WASM module to an OCI registry",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.module = args[0]

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -7,7 +7,7 @@ import (
 	"oras.land/oras-go/pkg/oras"
 )
 
-// Pull pulls a WASM module from an OCI registry given a reference
+// Pull pulls a Wasm module from an OCI registry given a reference
 func Pull(ref, outFile string, insecure, useHTTP bool) error {
 	ctx, resolver, store := newORASContext(insecure, useHTTP)
 

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -7,7 +7,7 @@ import (
 	"oras.land/oras-go/pkg/oras"
 )
 
-// Pull pulls a Wasm module from an OCI registry given a reference
+// Pull pulls a WASM module from an OCI registry given a reference
 func Pull(ref, outFile string, insecure, useHTTP bool) error {
 	ctx, resolver, store := newORASContext(insecure, useHTTP)
 

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -8,7 +8,7 @@ import (
 	"oras.land/oras-go/pkg/oras"
 )
 
-// Push pushes a WASM module an OCI registry
+// Push pushes a WASM module to an OCI registry
 func Push(ref, module string, insecure, useHTTP bool) error {
 	ctx, resolver, store := newORASContext(insecure, useHTTP)
 


### PR DESCRIPTION
This PR fixes some typos in descriptions for commands and flags. 

There are also two small fixes in code comments. (Fixing typos in code comments has almost no value, however I just stumbled upon them) 😄 